### PR TITLE
FIX Use cached SiteTree object for history instead of creating a temporary object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install with composer by running `composer require silverstripe/versionfeed` in 
 
 For usage instructions see [user manual](docs/en/userguide/index.md).
 
-### Translations
+## Translations
 
 Translations of the natural language strings are managed through a third party translation interface, transifex.com. Newly added strings will be periodically uploaded there for translation, and any new translations will be merged back to the project source code.
 

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -23,8 +23,10 @@ for the current page. You can override this behaviour by defining the `getDefaul
 and returning the URL of your desired RSS feed:
 
 ```php
-class MyPage extends Page {
-	function getDefaultRSSLink() {
+class MyPage extends Page
+{
+	public function getDefaultRSSLink()
+	{
 		return $this->Link('myrssfeed');
 	}
 }
@@ -34,7 +36,7 @@ This can be used in templates as `$DefaultRSSLink`.
 
 ### Rate limiting and caching
 
-By default all content is filtered based on the rules specified in `versionfeed/_config/versionfeed.yml`.
+By default all content is filtered based on the rules specified in `vendor/silverstripe/versionfeed/_config/versionfeed.yml`.
 Two filters are applied on top of one another:
 
  * `SilverStripe\VersionFeed\Filters\CachedContentFilter` provides caching of versions based on an identifier built up of the record ID and the 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -9,4 +9,3 @@ en:
   SilverStripe\VersionFeed\VersionFeedSiteConfig:
     ALLCHANGES: 'All page changes'
     ALLCHANGESLABEL: 'Make global changes feed public'
-    Warning: 'Publicising the history will also disclose the changes that have at the time been protected from the public view.'

--- a/src/VersionFeedController.php
+++ b/src/VersionFeedController.php
@@ -128,8 +128,8 @@ class VersionFeedController extends Extension
                     // Check if the page should be visible.
                     // WARNING: although we are providing historical details, we check the current configuration.
                     $id = $record['RecordID'];
-                    $page = DataObject::get_by_id(SiteTree::class, $id);
                     if (!isset($canView[$id])) {
+                        $page = DataObject::get_by_id(SiteTree::class, $id);
                         $canView[$id] = $page && $page->canView(Security::getCurrentUser());
                     }
                     if (!$canView[$id]) {
@@ -137,7 +137,8 @@ class VersionFeedController extends Extension
                     }
 
                     // Get the diff to the previous version.
-                    $version = $page;
+                    $record['ID'] = $record['RecordID'];
+                    $version = SiteTree::create($record);
                     if ($diff = $version->getDiff()) {
                         $changeList->push($diff);
                     }

--- a/src/VersionFeedSiteConfig.php
+++ b/src/VersionFeedSiteConfig.php
@@ -2,11 +2,10 @@
 
 namespace SilverStripe\VersionFeed;
 
-use SilverStripe\Forms\FieldList;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\VersionFeed\VersionFeed;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldGroup;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
 
 /**
@@ -39,7 +38,7 @@ class VersionFeedSiteConfig extends DataExtension
             FieldGroup::create(new CheckboxField('AllChangesEnabled', $this->owner->fieldLabel('AllChangesEnabled')))
                 ->setTitle(_t(__CLASS__ . '.ALLCHANGES', 'All page changes'))
                 ->setDescription(_t(
-                    __CLASS__ . '.Warning',
+                    'SilverStripe\\VersionFeed\\VersionFeed.Warning',
                     "Publicising the history will also disclose the changes that have at the time been protected " .
                     "from the public view."
                 ))

--- a/tests/VersionFeedFunctionalTest.php
+++ b/tests/VersionFeedFunctionalTest.php
@@ -54,7 +54,7 @@ class VersionFeedFunctionalTest extends FunctionalTest
         Config::modify()->set(RateLimitFilter::class, 'lock_cooldown', false);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Director::config()->set('alternate_base_url', null);
         
@@ -68,24 +68,37 @@ class VersionFeedFunctionalTest extends FunctionalTest
         $page = $this->createPageWithChanges(array('PublicHistory' => false));
 
         $response = $this->get($page->RelativeLink('changes'));
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(
+            404,
+            $response->getStatusCode(),
+            'With Page\'s "PublicHistory" disabled, `changes` action response code should be 404'
+        );
 
         $response = $this->get($page->RelativeLink('allchanges'));
         $this->assertEquals(200, $response->getStatusCode());
         $xml = simplexml_load_string($response->getBody());
-        $this->assertFalse((bool)$xml->channel->item);
+        $this->assertFalse(
+            (bool)$xml->channel->item,
+            'With Page\'s "PublicHistory" disabled, `allchanges` action should not have an item in the channel'
+        );
 
         $page = $this->createPageWithChanges(array('PublicHistory' => true));
 
         $response = $this->get($page->RelativeLink('changes'));
         $this->assertEquals(200, $response->getStatusCode());
         $xml = simplexml_load_string($response->getBody());
-        $this->assertTrue((bool)$xml->channel->item);
+        $this->assertTrue(
+            (bool)$xml->channel->item,
+            'With Page\'s "PublicHistory" enabled, `changes` action should have an item in the channel'
+        );
 
         $response = $this->get($page->RelativeLink('allchanges'));
         $this->assertEquals(200, $response->getStatusCode());
         $xml = simplexml_load_string($response->getBody());
-        $this->assertTrue((bool)$xml->channel->item);
+        $this->assertTrue(
+            (bool)$xml->channel->item,
+            'With "PublicHistory" enabled, `allchanges` action should have an item in the channel'
+        );
     }
 
     public function testRateLimiting()
@@ -148,7 +161,7 @@ class VersionFeedFunctionalTest extends FunctionalTest
         Config::modify()->set(CachedContentFilter::class, 'cache_enabled', false);
     }
 
-    public function testContainsChangesForPageOnly()
+    public function testChangesActionContainsChangesForCurrentPageOnly()
     {
         $page1 = $this->createPageWithChanges(array('Title' => 'Page1'));
         $page2 = $this->createPageWithChanges(array('Title' => 'Page2'));
@@ -172,7 +185,7 @@ class VersionFeedFunctionalTest extends FunctionalTest
         $this->assertContains('Changed: Page2', $titles);
     }
 
-    public function testContainsAllChangesForAllPages()
+    public function testAllChangesActionContainsAllChangesForAllPages()
     {
         $page1 = $this->createPageWithChanges(array('Title' => 'Page1'));
         $page2 = $this->createPageWithChanges(array('Title' => 'Page2'));

--- a/tests/VersionFeedTest.php
+++ b/tests/VersionFeedTest.php
@@ -3,24 +3,20 @@
 namespace SilverStripe\VersionFeed\Tests;
 
 use Page;
+use SilverStripe\CMS\Controllers\ContentController;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Versioned\Versioned;
 use SilverStripe\VersionFeed\VersionFeed;
 use SilverStripe\VersionFeed\VersionFeedController;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\CMS\Controllers\ContentController;
 
 class VersionFeedTest extends SapphireTest
 {
-
     protected $usesDatabase = true;
 
     protected static $required_extensions = [
         SiteTree::class => [VersionFeed::class],
         ContentController::class => [VersionFeedController::class],
-    ];
-
-    protected $illegalExtensions = [
-        'SiteTree' => ['Translatable']
     ];
 
     public function testDiffedChangesExcludesRestrictedItems()
@@ -37,11 +33,11 @@ class VersionFeedTest extends SapphireTest
     {
         $page = new Page(['Title' => 'My Title']);
         $page->write();
-        $page->publish('Stage', 'Live');
+        $page->copyVersionToStage(Versioned::STAGE, Versioned::LIVE);
     
         $page->Title = 'My Changed Title';
         $page->write();
-        $page->publish('Stage', 'Live');
+        $page->copyVersionToStage(Versioned::STAGE, Versioned::LIVE);
 
         $page->Title = 'My Unpublished Changed Title';
         $page->write();

--- a/tests/VersionFeedTest.php
+++ b/tests/VersionFeedTest.php
@@ -33,11 +33,11 @@ class VersionFeedTest extends SapphireTest
     {
         $page = new Page(['Title' => 'My Title']);
         $page->write();
-        $page->copyVersionToStage(Versioned::STAGE, Versioned::LIVE);
+        $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
     
         $page->Title = 'My Changed Title';
         $page->write();
-        $page->copyVersionToStage(Versioned::STAGE, Versioned::LIVE);
+        $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
         $page->Title = 'My Unpublished Changed Title';
         $page->write();


### PR DESCRIPTION
Fixes #47 and fixes #46

I'm not entirely sure that this is the best fix. @NightJar what do you think?