### PR TITLE
FIX allow allchanges to handle removed Page types

### DIFF
--- a/src/Filters/ContentFilter.php
+++ b/src/Filters/ContentFilter.php
@@ -39,7 +39,7 @@ abstract class ContentFilter
     /**
      * Gets the cache to use
      *
-     * @return Zend_Cache_Frontend
+     * @return CacheInterface
      */
     protected function getCache()
     {

--- a/src/VersionFeed.php
+++ b/src/VersionFeed.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\View\Parsers\Diff;
+use SilverStripe\CMS\Model\SiteTree;
 
 class VersionFeed extends SiteTreeExtension
 {
@@ -114,7 +115,16 @@ class VersionFeed extends SiteTreeExtension
                 }
 
                 // Copy the link so it can be cached.
-                $version->GeneratedLink = $version->AbsoluteLink();
+                $oldPage = $version->getField('object');
+                if (!$oldPage instanceof SiteTree) {
+                    // We only need enough info to generate the link...
+                    $oldPage = SiteTree::create([
+                        'ID' => $oldPage->ID,
+                        'URLSegment' => $oldPage->URLSegment,
+                        'ParentID' => $oldPage->ParentID
+                    ]);
+                }
+                $version->GeneratedLink = $oldPage->AbsoluteLink();
             }
 
             // Omit the versions that haven't been visibly changed (only takes the above fields into consideration).

--- a/src/VersionFeedController.php
+++ b/src/VersionFeedController.php
@@ -77,7 +77,7 @@ class VersionFeedController extends Extension
 
         // Cache the diffs to remove DOS possibility.
         $target = $this->owner;
-        $key = implode('_', array('changes', $this->owner->ID, $this->owner->Version));
+        $key = implode('_', array('changes', $target->ID, $target->Version));
         $entries = $this->filterContent($key, function () use ($target) {
             return $target->getDiffList(null, Config::inst()->get(VersionFeed::class, 'changes_limit'));
         });


### PR DESCRIPTION
If a there exists at some point in the history a class that no longer
exists, Versioned will create it as a `DataObject` as opposed to some form
of the `SiteTree` superclass. This would break the absolute link
funcitonality, so we should make the version at least an instance of
SiteTree so we can generate the link accurately (without fatal errors).