### PR TITLE
Update docs to match rename of checkbox in CMS

### DIFF
--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -16,12 +16,12 @@ Make sure that your SilverStripe installation has the [versionfeed](http://addon
 
 There are two feeds that are automatically created for each page:
 
-* Page changes: This feed will display all published versions of the page, highlighting any additions or deletions with underscores or strikethroughs. It is accessible with the `changes` action - so `http://mysite.com/mypage/changes`
+* Page changes: This feed will display all published versions of the page, highlighting any additions or deletions with underscores or strikethroughs respectively. It is accessible with the `changes` action - so `http://mysite.com/mypage/changes`
 * Site changes: This will aggregate all the per-page change feeds into one feed and display the most recent 20. It is accessible from any page with the `allchanges` action - so `http://mysite.com/home/allchanges`
 
 ## Enabling / disabling
 
-You can enable or disable the feed on a per-page basis by checking or unchecking the *Public History* checkbox in the Settings tab of each page. If a page has the Public History option, unchecked, it will not appear in the allchanges feed.
+You can enable or disable the feed on a per-page basis by checking or unchecking the *Make history public* checkbox (if available) in the Settings tab of each page. If a page has the Make history public option unchecked, it will not appear in the allchanges feed.
 
 The allchanges feed can also be disabled by unchecking the "All page changes" checkbox in the "Settings" section in the cms.
 
@@ -29,4 +29,4 @@ The allchanges feed can also be disabled by unchecking the "All page changes" ch
 
 A page's history will be completely visible when it has public history enabled, even if some updates were made when it was restricted to only being viewed by authenticated users. So if a page has ever had confidential data on it, it is best to not enable this feature unless the data has entered the public domain.
 
-There is a warning explaining this fact next to the *Public History* checkbox.
+There is a warning explaining this fact next to the *Make history public* checkbox.


### PR DESCRIPTION
'Public History' was renamed to 'Make history public' - this is now reflected in the docs. Also, `allchanges_enabled` and `canges_enabled` within versionfeed.yml are false by default. That means, unless enabled by a dev, the CMS user won't be able to see the checkbox referred to in the user guide. Therefore, a "if available" was added in brackets to avoid confusion.